### PR TITLE
fix: fixing build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-function build() {
+build() {
   rm -rf ./$1/target
   cd $1
   cargo build --release


### PR DESCRIPTION
When using functions on `.sh` files, the `function` prefix isn't necessary. Actually, if you try to run the script with `./build.sh`, it throws an error: `./build.sh: 1: ./build.sh: Syntax error: "(" unexpected`.