### PR TITLE
Check for existence of ZSH plugins directory in install script before copying files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,9 @@
+if [ -z "$1" ]
+then
+    echo "Plugins directory not specified, please pass your zsh plugins directory as a parameter."
+    exit 1
+fi
+
 if [ ! -d $1/yarn-autocompletions ]
 then
     mkdir $1/yarn-autocompletions


### PR DESCRIPTION
Hey there 👋 Thanks for an awesome project!

It's working perfectly for me, however I noticed a quick little issue in the install process – when running the `install.sh` script without a plugins directory parameter, the script will attempt to write to `/`. I've added some quick validation to ensure that the user has passed in a parameter before attempting the copy.

Previously:

    $ ./install.sh 
    mkdir: /yarn-autocompletions: Permission denied
    cp: /yarn-autocompletions: Permission denied
    cp: /yarn-autocompletions: Permission denied

Now:

    $ ./install.sh 
    Plugins directory not specified, please pass your zsh plugins directory as a parameter.

Thanks again! 🌟 