### PR TITLE
Add compdef

### DIFF
--- a/yarn-autocompletions.plugin.zsh
+++ b/yarn-autocompletions.plugin.zsh
@@ -30,3 +30,5 @@ _yarn() {
             ;;
     esac
 }
+
+compdef _yarn yarn


### PR DESCRIPTION
The `compdef` was accidentally removed in 
https://github.com/g-plane/zsh-yarn-autocompletions/commit/0fa9e93d2a63416929d7ceb96b369a8a1c5deb80#diff-188085b95c22185f0026fe08e980444a

Fix issue https://github.com/g-plane/zsh-yarn-autocompletions/issues/21