### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ plugins=(
 
 Restart your terminal.
 
+### Fig 
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-yarn-autocompletions` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-yarn-autocompletions_g-plane" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### With a plugin manager
 
 #### [zinit](https://github.com/zdharma/zinit)


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zsh yarn autocompletions is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!
